### PR TITLE
Fix timezone loading error by embedding tzdata

### DIFF
--- a/internal/bot/messagesender.go
+++ b/internal/bot/messagesender.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"time"
+	_ "time/tzdata" // Embed timezone database for containerized environments
 
 	"klutco-lil-helper/internal/model"
 


### PR DESCRIPTION
Embeds the timezone database into the binary by importing time/tzdata. This resolves the "unknown time zone America/New_York" error that occurs in containerized environments where the timezone database may not be available.

The time/tzdata package is part of Go's standard library and embedding it ensures timezone data is always available regardless of the deployment environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)